### PR TITLE
[codex] Fix GitHub Actions runner compatibility

### DIFF
--- a/.github/scripts/select_ios_simulator.py
+++ b/.github/scripts/select_ios_simulator.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import re
+import subprocess
+from typing import TypedDict
+
+
+class Simulator(TypedDict):
+    major: int
+    minor: int
+    name: str
+    udid: str
+
+
+runtime_pattern = re.compile(r"iOS-(\d+)-(\d+)$")
+preferred_names = [
+    "iPhone 17 Pro",
+    "iPhone 17",
+    "iPhone 17 Pro Max",
+    "iPhone 17e",
+    "iPhone Air",
+    "iPhone 16 Pro",
+    "iPhone 16",
+]
+
+
+def choose_simulator() -> Simulator:
+    raw = subprocess.check_output(
+        ["xcrun", "simctl", "list", "devices", "available", "-j"],
+        text=True,
+    )
+    devices_by_runtime = json.loads(raw)["devices"]
+
+    candidates: list[Simulator] = []
+    for runtime, devices in devices_by_runtime.items():
+        match = runtime_pattern.search(runtime)
+        if not match:
+            continue
+
+        major, minor = (int(part) for part in match.groups())
+        for device in devices:
+            name = device["name"]
+            if not device.get("isAvailable") or not name.startswith("iPhone"):
+                continue
+            candidates.append(
+                {
+                    "major": major,
+                    "minor": minor,
+                    "name": name,
+                    "udid": device["udid"],
+                }
+            )
+
+    if not candidates:
+        raise SystemExit("No available iPhone simulator destinations found.")
+
+    latest_runtime = max((candidate["major"], candidate["minor"]) for candidate in candidates)
+    latest_candidates = [
+        candidate
+        for candidate in candidates
+        if (candidate["major"], candidate["minor"]) == latest_runtime
+    ]
+
+    for preferred_name in preferred_names:
+        for candidate in latest_candidates:
+            if candidate["name"] == preferred_name:
+                return candidate
+
+    return sorted(latest_candidates, key=lambda candidate: candidate["name"])[0]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--field",
+        choices=["destination", "udid"],
+        default="destination",
+        help="Which selected simulator field to print.",
+    )
+    args = parser.parse_args()
+
+    chosen = choose_simulator()
+    destination = (
+        f"platform=iOS Simulator,OS={chosen['major']}.{chosen['minor']},name={chosen['name']}"
+    )
+
+    if args.field == "udid":
+        print(chosen["udid"])
+        return
+
+    print(destination)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,25 +9,117 @@ permissions:
 
 jobs:
   macos:
-    runs-on: macos-latest
+    runs-on: macos-26
     steps:
       - name: Checkout
         uses: actions/checkout@v6
 
       - name: Build macOS
-        run: xcodebuild -scheme macOS -configuration Debug build
+        run: |
+          xcodebuild \
+            -scheme macOS \
+            -configuration Debug \
+            CODE_SIGNING_ALLOWED=NO \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGN_IDENTITY="" \
+            build
 
       - name: Test macOS
-        run: xcodebuild test -scheme macOS
+        run: |
+          xcodebuild \
+            test \
+            -scheme macOS \
+            CODE_SIGNING_ALLOWED=NO \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGN_IDENTITY=""
 
   ios:
-    runs-on: macos-latest
+    runs-on: macos-26
     steps:
       - name: Checkout
         uses: actions/checkout@v6
 
+      - name: Select iOS simulator
+        id: ios-simulator
+        run: |
+          destination="$(
+            python3 - <<'PY'
+            import json
+            import re
+            import subprocess
+
+            raw = subprocess.check_output(
+                ["xcrun", "simctl", "list", "devices", "available", "-j"],
+                text=True,
+            )
+            devices_by_runtime = json.loads(raw)["devices"]
+            runtime_pattern = re.compile(r"iOS-(\d+)-(\d+)$")
+            preferred_names = [
+                "iPhone 17 Pro",
+                "iPhone 17",
+                "iPhone 17 Pro Max",
+                "iPhone 17e",
+                "iPhone Air",
+                "iPhone 16 Pro",
+                "iPhone 16",
+            ]
+
+            candidates = []
+            for runtime, devices in devices_by_runtime.items():
+                match = runtime_pattern.search(runtime)
+                if not match:
+                    continue
+
+                major, minor = (int(part) for part in match.groups())
+                for device in devices:
+                    name = device["name"]
+                    if not device.get("isAvailable") or not name.startswith("iPhone"):
+                        continue
+                    candidates.append((major, minor, name))
+
+            if not candidates:
+                raise SystemExit("No available iPhone simulator destinations found.")
+
+            latest_runtime = max((major, minor) for major, minor, _ in candidates)
+            latest_candidates = [candidate for candidate in candidates if candidate[:2] == latest_runtime]
+
+            chosen = None
+            for preferred_name in preferred_names:
+                for candidate in latest_candidates:
+                    if candidate[2] == preferred_name:
+                        chosen = candidate
+                        break
+                if chosen:
+                    break
+
+            if chosen is None:
+                chosen = sorted(latest_candidates, key=lambda candidate: candidate[2])[0]
+
+            major, minor, name = chosen
+            print(f"platform=iOS Simulator,OS={major}.{minor},name={name}")
+            PY
+          )"
+
+          echo "destination=$destination" >> "$GITHUB_OUTPUT"
+          echo "Using simulator destination: $destination"
+
       - name: Build iOS
-        run: xcodebuild -scheme iOS -configuration Debug build -destination "platform=iOS Simulator,name=iPhone 16 Pro,OS=latest"
+        run: |
+          xcodebuild \
+            -scheme iOS \
+            -configuration Debug \
+            -destination "${{ steps.ios-simulator.outputs.destination }}" \
+            CODE_SIGNING_ALLOWED=NO \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGN_IDENTITY="" \
+            build
 
       - name: Test iOS
-        run: xcodebuild test -scheme iOS -destination "platform=iOS Simulator,name=iPhone 16 Pro,OS=latest"
+        run: |
+          xcodebuild \
+            test \
+            -scheme iOS \
+            -destination "${{ steps.ios-simulator.outputs.destination }}" \
+            CODE_SIGNING_ALLOWED=NO \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGN_IDENTITY=""

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,66 +42,18 @@ jobs:
       - name: Select iOS simulator
         id: ios-simulator
         run: |
-          destination="$(
-            python3 - <<'PY'
-            import json
-            import re
-            import subprocess
-
-            raw = subprocess.check_output(
-                ["xcrun", "simctl", "list", "devices", "available", "-j"],
-                text=True,
-            )
-            devices_by_runtime = json.loads(raw)["devices"]
-            runtime_pattern = re.compile(r"iOS-(\d+)-(\d+)$")
-            preferred_names = [
-                "iPhone 17 Pro",
-                "iPhone 17",
-                "iPhone 17 Pro Max",
-                "iPhone 17e",
-                "iPhone Air",
-                "iPhone 16 Pro",
-                "iPhone 16",
-            ]
-
-            candidates = []
-            for runtime, devices in devices_by_runtime.items():
-                match = runtime_pattern.search(runtime)
-                if not match:
-                    continue
-
-                major, minor = (int(part) for part in match.groups())
-                for device in devices:
-                    name = device["name"]
-                    if not device.get("isAvailable") or not name.startswith("iPhone"):
-                        continue
-                    candidates.append((major, minor, name))
-
-            if not candidates:
-                raise SystemExit("No available iPhone simulator destinations found.")
-
-            latest_runtime = max((major, minor) for major, minor, _ in candidates)
-            latest_candidates = [candidate for candidate in candidates if candidate[:2] == latest_runtime]
-
-            chosen = None
-            for preferred_name in preferred_names:
-                for candidate in latest_candidates:
-                    if candidate[2] == preferred_name:
-                        chosen = candidate
-                        break
-                if chosen:
-                    break
-
-            if chosen is None:
-                chosen = sorted(latest_candidates, key=lambda candidate: candidate[2])[0]
-
-            major, minor, name = chosen
-            print(f"platform=iOS Simulator,OS={major}.{minor},name={name}")
-            PY
-          )"
-
+          destination="$(python3 .github/scripts/select_ios_simulator.py)"
+          udid="$(python3 .github/scripts/select_ios_simulator.py --field udid)"
           echo "destination=$destination" >> "$GITHUB_OUTPUT"
+          echo "udid=$udid" >> "$GITHUB_OUTPUT"
           echo "Using simulator destination: $destination"
+
+      - name: Boot iOS simulator
+        run: |
+          xcrun simctl shutdown "${{ steps.ios-simulator.outputs.udid }}" || true
+          xcrun simctl boot "${{ steps.ios-simulator.outputs.udid }}"
+          xcrun simctl bootstatus "${{ steps.ios-simulator.outputs.udid }}" -b
+          xcrun simctl uninstall "${{ steps.ios-simulator.outputs.udid }}" com.codedbydan.FragmentSnippetManager || true
 
       - name: Build iOS
         run: |
@@ -109,6 +61,7 @@ jobs:
             -scheme iOS \
             -configuration Debug \
             -destination "${{ steps.ios-simulator.outputs.destination }}" \
+            -destination-timeout 180 \
             CODE_SIGNING_ALLOWED=NO \
             CODE_SIGNING_REQUIRED=NO \
             CODE_SIGN_IDENTITY="" \
@@ -120,6 +73,7 @@ jobs:
             test \
             -scheme iOS \
             -destination "${{ steps.ios-simulator.outputs.destination }}" \
+            -destination-timeout 180 \
             CODE_SIGNING_ALLOWED=NO \
             CODE_SIGNING_REQUIRED=NO \
             CODE_SIGN_IDENTITY=""

--- a/.github/workflows/iOS-test.yml
+++ b/.github/workflows/iOS-test.yml
@@ -9,13 +9,92 @@ permissions:
 
 jobs:
   test:
-    runs-on: macos-latest
+    runs-on: macos-26
     steps:
       - name: Checkout
         uses: actions/checkout@v6
 
+      - name: Select iOS simulator
+        id: ios-simulator
+        run: |
+          destination="$(
+            python3 - <<'PY'
+            import json
+            import re
+            import subprocess
+
+            raw = subprocess.check_output(
+                ["xcrun", "simctl", "list", "devices", "available", "-j"],
+                text=True,
+            )
+            devices_by_runtime = json.loads(raw)["devices"]
+            runtime_pattern = re.compile(r"iOS-(\d+)-(\d+)$")
+            preferred_names = [
+                "iPhone 17 Pro",
+                "iPhone 17",
+                "iPhone 17 Pro Max",
+                "iPhone 17e",
+                "iPhone Air",
+                "iPhone 16 Pro",
+                "iPhone 16",
+            ]
+
+            candidates = []
+            for runtime, devices in devices_by_runtime.items():
+                match = runtime_pattern.search(runtime)
+                if not match:
+                    continue
+
+                major, minor = (int(part) for part in match.groups())
+                for device in devices:
+                    name = device["name"]
+                    if not device.get("isAvailable") or not name.startswith("iPhone"):
+                        continue
+                    candidates.append((major, minor, name))
+
+            if not candidates:
+                raise SystemExit("No available iPhone simulator destinations found.")
+
+            latest_runtime = max((major, minor) for major, minor, _ in candidates)
+            latest_candidates = [candidate for candidate in candidates if candidate[:2] == latest_runtime]
+
+            chosen = None
+            for preferred_name in preferred_names:
+                for candidate in latest_candidates:
+                    if candidate[2] == preferred_name:
+                        chosen = candidate
+                        break
+                if chosen:
+                    break
+
+            if chosen is None:
+                chosen = sorted(latest_candidates, key=lambda candidate: candidate[2])[0]
+
+            major, minor, name = chosen
+            print(f"platform=iOS Simulator,OS={major}.{minor},name={name}")
+            PY
+          )"
+
+          echo "destination=$destination" >> "$GITHUB_OUTPUT"
+          echo "Using simulator destination: $destination"
+
       - name: Build iOS
-        run: xcodebuild -scheme iOS -configuration Debug build -destination "platform=iOS Simulator,name=iPhone 16 Pro,OS=latest"
+        run: |
+          xcodebuild \
+            -scheme iOS \
+            -configuration Debug \
+            -destination "${{ steps.ios-simulator.outputs.destination }}" \
+            CODE_SIGNING_ALLOWED=NO \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGN_IDENTITY="" \
+            build
 
       - name: Test iOS
-        run: xcodebuild test -scheme iOS -destination "platform=iOS Simulator,name=iPhone 16 Pro,OS=latest"
+        run: |
+          xcodebuild \
+            test \
+            -scheme iOS \
+            -destination "${{ steps.ios-simulator.outputs.destination }}" \
+            CODE_SIGNING_ALLOWED=NO \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGN_IDENTITY=""

--- a/.github/workflows/iOS-test.yml
+++ b/.github/workflows/iOS-test.yml
@@ -17,66 +17,18 @@ jobs:
       - name: Select iOS simulator
         id: ios-simulator
         run: |
-          destination="$(
-            python3 - <<'PY'
-            import json
-            import re
-            import subprocess
-
-            raw = subprocess.check_output(
-                ["xcrun", "simctl", "list", "devices", "available", "-j"],
-                text=True,
-            )
-            devices_by_runtime = json.loads(raw)["devices"]
-            runtime_pattern = re.compile(r"iOS-(\d+)-(\d+)$")
-            preferred_names = [
-                "iPhone 17 Pro",
-                "iPhone 17",
-                "iPhone 17 Pro Max",
-                "iPhone 17e",
-                "iPhone Air",
-                "iPhone 16 Pro",
-                "iPhone 16",
-            ]
-
-            candidates = []
-            for runtime, devices in devices_by_runtime.items():
-                match = runtime_pattern.search(runtime)
-                if not match:
-                    continue
-
-                major, minor = (int(part) for part in match.groups())
-                for device in devices:
-                    name = device["name"]
-                    if not device.get("isAvailable") or not name.startswith("iPhone"):
-                        continue
-                    candidates.append((major, minor, name))
-
-            if not candidates:
-                raise SystemExit("No available iPhone simulator destinations found.")
-
-            latest_runtime = max((major, minor) for major, minor, _ in candidates)
-            latest_candidates = [candidate for candidate in candidates if candidate[:2] == latest_runtime]
-
-            chosen = None
-            for preferred_name in preferred_names:
-                for candidate in latest_candidates:
-                    if candidate[2] == preferred_name:
-                        chosen = candidate
-                        break
-                if chosen:
-                    break
-
-            if chosen is None:
-                chosen = sorted(latest_candidates, key=lambda candidate: candidate[2])[0]
-
-            major, minor, name = chosen
-            print(f"platform=iOS Simulator,OS={major}.{minor},name={name}")
-            PY
-          )"
-
+          destination="$(python3 .github/scripts/select_ios_simulator.py)"
+          udid="$(python3 .github/scripts/select_ios_simulator.py --field udid)"
           echo "destination=$destination" >> "$GITHUB_OUTPUT"
+          echo "udid=$udid" >> "$GITHUB_OUTPUT"
           echo "Using simulator destination: $destination"
+
+      - name: Boot iOS simulator
+        run: |
+          xcrun simctl shutdown "${{ steps.ios-simulator.outputs.udid }}" || true
+          xcrun simctl boot "${{ steps.ios-simulator.outputs.udid }}"
+          xcrun simctl bootstatus "${{ steps.ios-simulator.outputs.udid }}" -b
+          xcrun simctl uninstall "${{ steps.ios-simulator.outputs.udid }}" com.codedbydan.FragmentSnippetManager || true
 
       - name: Build iOS
         run: |
@@ -84,6 +36,7 @@ jobs:
             -scheme iOS \
             -configuration Debug \
             -destination "${{ steps.ios-simulator.outputs.destination }}" \
+            -destination-timeout 180 \
             CODE_SIGNING_ALLOWED=NO \
             CODE_SIGNING_REQUIRED=NO \
             CODE_SIGN_IDENTITY="" \
@@ -95,6 +48,7 @@ jobs:
             test \
             -scheme iOS \
             -destination "${{ steps.ios-simulator.outputs.destination }}" \
+            -destination-timeout 180 \
             CODE_SIGNING_ALLOWED=NO \
             CODE_SIGNING_REQUIRED=NO \
             CODE_SIGN_IDENTITY=""

--- a/.github/workflows/macOS-test.yml
+++ b/.github/workflows/macOS-test.yml
@@ -9,13 +9,26 @@ permissions:
 
 jobs:
   test:
-    runs-on: macos-latest
+    runs-on: macos-26
     steps:
       - name: Checkout
         uses: actions/checkout@v6
 
       - name: Build macOS
-        run: xcodebuild -scheme macOS -configuration Debug build
+        run: |
+          xcodebuild \
+            -scheme macOS \
+            -configuration Debug \
+            CODE_SIGNING_ALLOWED=NO \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGN_IDENTITY="" \
+            build
 
       - name: Test macOS
-        run: xcodebuild test -scheme macOS
+        run: |
+          xcodebuild \
+            test \
+            -scheme macOS \
+            CODE_SIGNING_ALLOWED=NO \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGN_IDENTITY=""


### PR DESCRIPTION
## Summary
- move GitHub Actions jobs from `macos-latest` to `macos-26` so the workflow uses an Xcode 26 image that matches the app's iOS 26/macOS 26 deployment targets
- disable code signing for CI-only `xcodebuild` build/test invocations so hosted runners do not require the maintainer's local signing certificate
- replace the hard-coded `iPhone 16 Pro` destination with a small simulator-selection step that chooses an available iPhone runtime/device from the installed image

## Why CI was failing
- the `macos` job tried to sign the app on a hosted runner that does not have the `Mac Development` certificate for team `WRJ8J85K4Q`
- the `ios` job requested `platform=iOS Simulator,name=iPhone 16 Pro,OS=latest`, but that destination is no longer available on the current Xcode 26 simulator set
- `macos-latest` currently resolves to an older image than this repo's 26.x toolchain expectations, so the workflow needs to target the matching runner explicitly

## Test Plan
- `xcodebuild -scheme macOS -configuration Debug CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY='' build -derivedDataPath /tmp/fragment-ci-fix-macos-build`
- `xcodebuild test -scheme macOS CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY='' -derivedDataPath /tmp/fragment-ci-fix-macos-test`
- `xcodebuild -scheme iOS -configuration Debug -destination "platform=iOS Simulator,OS=26.4,name=iPhone 17 Pro" CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY='' build -derivedDataPath /tmp/fragment-ci-fix-ios-build`
- `xcodebuild test -scheme iOS -destination "platform=iOS Simulator,OS=26.4,name=iPhone 17 Pro" CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY='' -derivedDataPath /tmp/fragment-ci-fix-ios-test`

## Notes
- the iOS simulator is selected dynamically in CI, so the workflow can follow the latest available iPhone runtime on the runner image instead of depending on a stale device name
- local workspace still has an untracked `AGENTS.md` that is not part of this PR
